### PR TITLE
Overflow protection

### DIFF
--- a/src/__tests__/parseTime.spec.ts
+++ b/src/__tests__/parseTime.spec.ts
@@ -120,4 +120,14 @@ describe('parseTime', () => {
             expect(parseTime(formatted24)).toEqual(12); // This is wrong
         });
     });
+
+    describe('# Overflow protection', () => {
+        const localTestTable = ['13:78', '50:20', '01:60', '11:90'];
+
+        localTestTable.forEach((input) => {
+            test(`should parse ${input} hours as null`, () => {
+                expect(parseTime(input)).toEqual(null);
+            });
+        });
+    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,10 @@ const parseTime = (inputStr: string, timeFormat: TimeFormat = '24h'): number | n
             break;
     }
 
+    if (hour >= MAX_HOUR_VALUE || minutes >= MINUTES_IN_HOUR) {
+        return null;
+    }
+
     return hour + Number.parseFloat((minutes / MINUTES_IN_HOUR).toFixed(2));
 };
 


### PR DESCRIPTION
No more parsing values like '13:78' correctly